### PR TITLE
Ignore nuget package build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
+
+# Nuget Packages BuildRelease.msbuild output
+/NuGetPackages


### PR DESCRIPTION
... so they don't accidentally get included in a commit.
