### PR TITLE
Added ability to visit EventInfo and LocalVariableInfo

### DIFF
--- a/Src/Albedo.UnitTests/Albedo.UnitTests.csproj
+++ b/Src/Albedo.UnitTests/Albedo.UnitTests.csproj
@@ -55,6 +55,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyElementTests.cs" />
+    <Compile Include="EventInfoElementTests.cs" />
+    <Compile Include="LocalVariableInfoElementTests.cs" />
     <Compile Include="ParameterInfoElementTests.cs" />
     <Compile Include="PropertyInfoElementTests.cs" />
     <Compile Include="TypeElementTests.cs" />

--- a/Src/Albedo.UnitTests/DelegatingReflectionVisitor.cs
+++ b/Src/Albedo.UnitTests/DelegatingReflectionVisitor.cs
@@ -15,6 +15,8 @@ namespace Ploeh.Albedo.UnitTests
             this.OnVisitParameterInfoElement = e => this;
             this.OnVisitPropertyInfoElement = e => this;
             this.OnVisitTypeElement = e => this;
+            this.OnVisitLocalVariableInfoElement = e => this;
+            this.OnVisitEventInfoElement = e => this;
         }
 
         public Func<AssemblyElement, IReflectionVisitor<T>> OnVisitAssemblyElement { get; set; }
@@ -24,6 +26,8 @@ namespace Ploeh.Albedo.UnitTests
         public Func<ParameterInfoElement, IReflectionVisitor<T>> OnVisitParameterInfoElement { get; set; }
         public Func<PropertyInfoElement, IReflectionVisitor<T>> OnVisitPropertyInfoElement { get; set; }
         public Func<TypeElement, IReflectionVisitor<T>> OnVisitTypeElement { get; set; }
+        public Func<LocalVariableInfoElement, IReflectionVisitor<T>> OnVisitLocalVariableInfoElement { get; set; }
+        public Func<EventInfoElement, IReflectionVisitor<T>> OnVisitEventInfoElement { get; set; }
 
         public virtual IReflectionVisitor<T> Visit(AssemblyElement assemblyElement)
         {
@@ -58,6 +62,16 @@ namespace Ploeh.Albedo.UnitTests
         public virtual IReflectionVisitor<T> Visit(TypeElement typeElement)
         {
             return OnVisitTypeElement(typeElement);
+        }
+
+        public virtual IReflectionVisitor<T> Visit(LocalVariableInfoElement localVariableInfoElement)
+        {
+            return OnVisitLocalVariableInfoElement(localVariableInfoElement);
+        }
+
+        public virtual IReflectionVisitor<T> Visit(EventInfoElement eventInfoElement)
+        {
+            return OnVisitEventInfoElement(eventInfoElement);
         }
     }
 }

--- a/Src/Albedo.UnitTests/EventInfoElementTests.cs
+++ b/Src/Albedo.UnitTests/EventInfoElementTests.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Ploeh.Albedo.UnitTests
+{
+    public class EventInfoElementTests
+    {
+        [Fact]
+        public void SutIsReflectionElement()  
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new EventInfoElement(TypeWithEvent.LocalEvent);
+            // Verify outcome
+            Assert.IsAssignableFrom<IReflectionElement>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void EventInfoIsCorrect()
+        {
+            // Fixture setup
+            var expected = TypeWithEvent.LocalEvent;
+            var sut = new EventInfoElement(expected);
+            // Exercise system
+            EventInfo actual = sut.EventInfo;
+            // Verify outcome
+            Assert.Equal(expected, actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void ConstructWithNullEventInfoThrows()
+        {
+            // Fixture setup
+            // Exercise system
+            // Verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                new EventInfoElement(null));
+            // Teardown
+        }
+
+        [Fact]
+        public void AcceptNullVisitorThrows()
+        {
+            // Fixture setup
+            var sut = new EventInfoElement(TypeWithEvent.LocalEvent);
+            // Exercise system
+            // Verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.Accept((IReflectionVisitor<object>)null));
+            // Teardown
+        }
+
+        [Fact]
+        public void AcceptCallsTheCorrectVisitorMethodAndReturnsTheCorrectInstance()
+        {
+            // Fixture setup
+            var expected = new DelegatingReflectionVisitor<int>();
+            var sut = new EventInfoElement(TypeWithEvent.LocalEvent);
+            var visitor = new DelegatingReflectionVisitor<int>
+            {
+                OnVisitEventInfoElement = e =>
+                    e == sut ? expected : new DelegatingReflectionVisitor<int>()
+            };
+
+            // Exercise system
+            var actual = sut.Accept(visitor);
+            // Verify outcome
+            Assert.Same(expected, actual);
+            // Teardown
+        }
+
+
+        class TypeWithEvent
+        {
+            public static EventInfo LocalEvent
+            {
+                get
+                {
+                    return typeof (TypeWithEvent).GetEvent("TheEvent");
+                }
+            }
+
+            public event EventHandler TheEvent
+            {
+                add { throw new NotImplementedException(); }
+                remove { throw new NotImplementedException(); }
+            }
+        }
+    }
+}

--- a/Src/Albedo.UnitTests/LocalVariableInfoElementTests.cs
+++ b/Src/Albedo.UnitTests/LocalVariableInfoElementTests.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Ploeh.Albedo.UnitTests
+{
+    public class LocalVariableInfoElementTests
+    {
+        [Fact]
+        public void SutIsReflectionElement()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new LocalVariableInfoElement(TypeWithLocalVariable.LocalVariable);
+            // Verify outcome
+            Assert.IsAssignableFrom<IReflectionElement>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void LocalVariableInfoIsCorrect()
+        {
+            // Fixture setup
+            var expected = TypeWithLocalVariable.LocalVariable;
+            var sut = new LocalVariableInfoElement(expected);
+            // Exercise system
+            LocalVariableInfo actual = sut.LocalVariableInfo;
+            // Verify outcome
+            Assert.Equal(expected, actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void ConstructWithNullLocalVariableInfoThrows()
+        {
+            // Fixture setup
+            // Exercise system
+            // Verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                new LocalVariableInfoElement(null));
+            // Teardown
+        }
+
+        [Fact]
+        public void AcceptNullVisitorThrows()
+        {
+            // Fixture setup
+            var sut = new LocalVariableInfoElement(TypeWithLocalVariable.LocalVariable);
+            // Exercise system
+            // Verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.Accept((IReflectionVisitor<object>)null));
+            // Teardown
+        }
+
+        [Fact]
+        public void AcceptCallsTheCorrectVisitorMethodAndReturnsTheCorrectInstance()
+        {
+            // Fixture setup
+            var expected = new DelegatingReflectionVisitor<int>();
+            var sut = new LocalVariableInfoElement(TypeWithLocalVariable.LocalVariable);
+            var visitor = new DelegatingReflectionVisitor<int>
+            {
+                OnVisitLocalVariableInfoElement = e =>
+                    e == sut ? expected : new DelegatingReflectionVisitor<int>()
+            };
+
+            // Exercise system
+            var actual = sut.Accept(visitor);
+            // Verify outcome
+            Assert.Same(expected, actual);
+            // Teardown
+        }
+
+
+        class TypeWithLocalVariable
+        {
+            public static LocalVariableInfo LocalVariable
+            {
+                get
+                {
+                    return typeof (TypeWithLocalVariable)
+                        .GetMethod("TheMethod")
+                        .GetMethodBody()
+                        .LocalVariables[0];
+                }
+            }
+
+            public void TheMethod()
+            {
+                // This is required to prevent the compiler from
+                // warning and optimising away the local variable.
+                var local = 1;
+                local = local + 1;
+                local = local + 2;
+            }
+        }
+    }
+}

--- a/Src/Albedo/Albedo.csproj
+++ b/Src/Albedo/Albedo.csproj
@@ -54,6 +54,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyElement.cs" />
+    <Compile Include="EventInfoElement.cs" />
     <Compile Include="ConstructorInfoElement.cs" />
     <Compile Include="FieldInfoElement.cs" />
     <Compile Include="MethodInfoElement.cs" />
@@ -61,6 +62,7 @@
     <Compile Include="IReflectionElement.cs" />
     <Compile Include="Fields.cs" />
     <Compile Include="Methods.cs" />
+    <Compile Include="LocalVariableInfoElement.cs" />
     <Compile Include="ParameterInfoElement.cs" />
     <Compile Include="Properties.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Src/Albedo/EventInfoElement.cs
+++ b/Src/Albedo/EventInfoElement.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Reflection;
+
+namespace Ploeh.Albedo
+{
+    /// <summary>
+    /// An <see cref="IReflectionElement"/> representing a <see cref="EventInfo"/> which
+    /// can be visited by an <see cref="IReflectionVisitor{T}"/> implementation.
+    /// </summary>
+    public class EventInfoElement : IReflectionElement
+    {
+        /// <summary>
+        /// Gets the <see cref="System.Reflection.EventInfo"/> instance this element represents.
+        /// </summary>
+        public EventInfo EventInfo { get; private set; }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="EventInfoElement"/> which represents
+        /// the specified <see cref="System.Reflection.EventInfo"/>.
+        /// </summary>
+        /// <param name="eventInfo">The <see cref="System.Reflection.EventInfo"/> this 
+        /// element represents.</param>
+        public EventInfoElement(EventInfo eventInfo)
+        {
+            if (eventInfo == null) throw new ArgumentNullException("eventInfo");
+            this.EventInfo = eventInfo;
+        }
+
+        /// <summary>
+        /// Accepts the provided <see cref="IReflectionVisitor{T}"/>, by calling the
+        /// appropriate strongly-typed <see cref="IReflectionVisitor{T}.Visit(EventInfoElement)"/>
+        /// method on the visitor.
+        /// </summary>
+        /// <typeparam name="T">The type of observation or result which the
+        /// <see cref="IReflectionVisitor{T}"/> instance produces when visiting nodes.</typeparam>
+        /// <param name="visitor">The <see cref="IReflectionVisitor{T}"/> instance.</param>
+        /// <returns>A (potentially) new <see cref="IReflectionVisitor{T}"/> instance which can be
+        /// used to continue the visiting process with potentially updated observations.</returns>
+        public IReflectionVisitor<T> Accept<T>(IReflectionVisitor<T> visitor)
+        {
+            if (visitor == null) throw new ArgumentNullException("visitor");
+            return visitor.Visit(this);
+        }
+    }
+}

--- a/Src/Albedo/IReflectionVisitor.cs
+++ b/Src/Albedo/IReflectionVisitor.cs
@@ -74,5 +74,23 @@
         /// <returns>A (potentially) new <see cref="IReflectionVisitor{T}"/> instance which can be
         /// used to continue the visiting process with potentially updated observations.</returns>
         IReflectionVisitor<T> Visit(TypeElement typeElement);
+
+        /// <summary>
+        /// Allows an <see cref="LocalVariableInfoElement"/> to be 'visited'. This method is called when the
+        /// element 'accepts' this visitor instance.
+        /// </summary>
+        /// <param name="localVariableInfoElement">The <see cref="LocalVariableInfoElement"/> being visited.</param>
+        /// <returns>A (potentially) new <see cref="IReflectionVisitor{T}"/> instance which can be
+        /// used to continue the visiting process with potentially updated observations.</returns>
+        IReflectionVisitor<T> Visit(LocalVariableInfoElement localVariableInfoElement);
+
+        /// <summary>
+        /// Allows an <see cref="EventInfoElement"/> to be 'visited'. This method is called when the
+        /// element 'accepts' this visitor instance.
+        /// </summary>
+        /// <param name="eventInfoElement">The <see cref="EventInfoElement"/> being visited.</param>
+        /// <returns>A (potentially) new <see cref="IReflectionVisitor{T}"/> instance which can be
+        /// used to continue the visiting process with potentially updated observations.</returns>
+        IReflectionVisitor<T> Visit(EventInfoElement eventInfoElement);
     }
 }

--- a/Src/Albedo/LocalVariableInfoElement.cs
+++ b/Src/Albedo/LocalVariableInfoElement.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Reflection;
+
+namespace Ploeh.Albedo
+{
+    /// <summary>
+    /// An <see cref="IReflectionElement"/> representing a <see cref="LocalVariableInfo"/> which
+    /// can be visited by an <see cref="IReflectionVisitor{T}"/> implementation.
+    /// </summary>
+    public class LocalVariableInfoElement : IReflectionElement
+    {
+        /// <summary>
+        /// Gets the <see cref="System.Reflection.LocalVariableInfo"/> instance this element represents.
+        /// </summary>
+        public LocalVariableInfo LocalVariableInfo { get; private set; }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="LocalVariableInfoElement"/> which represents
+        /// the specified <see cref="System.Reflection.LocalVariableInfo"/>.
+        /// </summary>
+        /// <param name="localVariableInfo">The <see cref="System.Reflection.LocalVariableInfo"/> this 
+        /// element represents.</param>
+        public LocalVariableInfoElement(LocalVariableInfo localVariableInfo)
+        {
+            if (localVariableInfo == null) throw new ArgumentNullException("localVariableInfo");
+            this.LocalVariableInfo = localVariableInfo;
+        }
+
+        /// <summary>
+        /// Accepts the provided <see cref="IReflectionVisitor{T}"/>, by calling the
+        /// appropriate strongly-typed <see cref="IReflectionVisitor{T}.Visit(LocalVariableInfoElement)"/>
+        /// method on the visitor.
+        /// </summary>
+        /// <typeparam name="T">The type of observation or result which the
+        /// <see cref="IReflectionVisitor{T}"/> instance produces when visiting nodes.</typeparam>
+        /// <param name="visitor">The <see cref="IReflectionVisitor{T}"/> instance.</param>
+        /// <returns>A (potentially) new <see cref="IReflectionVisitor{T}"/> instance which can be
+        /// used to continue the visiting process with potentially updated observations.</returns>
+        public IReflectionVisitor<T> Accept<T>(IReflectionVisitor<T> visitor)
+        {
+            if (visitor == null) throw new ArgumentNullException("visitor");
+            return visitor.Visit(this);
+        }
+    }
+}


### PR DESCRIPTION
Added the ability to visit: `EventInfo`, `LocalVariableInfo`.

See original [comment here](https://github.com/ploeh/Albedo/pull/5#discussion_r6972335).

See also #5, #12, #13, #15, #16 for more details.
