### PR TITLE
Fix local variable naming in structural equality tests: ci, mi, pi, par

### DIFF
--- a/Src/Albedo.UnitTests/ConstructorInfoElementTests.cs
+++ b/Src/Albedo.UnitTests/ConstructorInfoElementTests.cs
@@ -78,9 +78,9 @@ namespace Ploeh.Albedo.UnitTests
         [Fact]
         public void SutEqualsOtherIdenticalInstance()
         {
-            var c = TypeWithCtor.Ctor;
-            var sut = new ConstructorInfoElement(c);
-            var other = new ConstructorInfoElement(c);
+            var ci = TypeWithCtor.Ctor;
+            var sut = new ConstructorInfoElement(ci);
+            var other = new ConstructorInfoElement(ci);
 
             var actual = sut.Equals(other);
 
@@ -119,12 +119,12 @@ namespace Ploeh.Albedo.UnitTests
         [InlineData(typeof(ConstructorInfoElement))]
         public void GetHashCodeReturnsCorrectResult(Type t)
         {
-            var c = TypeWithCtor.Ctor;
-            var sut = new ConstructorInfoElement(c);
+            var ci = TypeWithCtor.Ctor;
+            var sut = new ConstructorInfoElement(ci);
 
             var actual = sut.GetHashCode();
 
-            var expected = c.GetHashCode();
+            var expected = ci.GetHashCode();
             Assert.Equal(expected, actual);
         }
 

--- a/Src/Albedo.UnitTests/MethodInfoElementTests.cs
+++ b/Src/Albedo.UnitTests/MethodInfoElementTests.cs
@@ -78,9 +78,9 @@ namespace Ploeh.Albedo.UnitTests
         [Fact]
         public void SutEqualsOtherIdenticalInstance()
         {
-            var c = TypeWithMethod.Method;
-            var sut = new MethodInfoElement(c);
-            var other = new MethodInfoElement(c);
+            var mi = TypeWithMethod.Method;
+            var sut = new MethodInfoElement(mi);
+            var other = new MethodInfoElement(mi);
 
             var actual = sut.Equals(other);
 
@@ -119,12 +119,12 @@ namespace Ploeh.Albedo.UnitTests
         [InlineData(typeof(MethodInfoElement))]
         public void GetHashCodeReturnsCorrectResult(Type t)
         {
-            var c = TypeWithMethod.Method;
-            var sut = new MethodInfoElement(c);
+            var mi = TypeWithMethod.Method;
+            var sut = new MethodInfoElement(mi);
 
             var actual = sut.GetHashCode();
 
-            var expected = c.GetHashCode();
+            var expected = mi.GetHashCode();
             Assert.Equal(expected, actual);
         }
 

--- a/Src/Albedo.UnitTests/ParameterInfoElementTests.cs
+++ b/Src/Albedo.UnitTests/ParameterInfoElementTests.cs
@@ -78,9 +78,9 @@ namespace Ploeh.Albedo.UnitTests
         [Fact]
         public void SutEqualsOtherIdenticalInstance()
         {
-            var c = TypeWithParameter.Parameter;
-            var sut = new ParameterInfoElement(c);
-            var other = new ParameterInfoElement(c);
+            var par = TypeWithParameter.Parameter;
+            var sut = new ParameterInfoElement(par);
+            var other = new ParameterInfoElement(par);
 
             var actual = sut.Equals(other);
 
@@ -119,12 +119,12 @@ namespace Ploeh.Albedo.UnitTests
         [InlineData(typeof(ParameterInfoElement))]
         public void GetHashCodeReturnsCorrectResult(Type t)
         {
-            var c = TypeWithParameter.Parameter;
-            var sut = new ParameterInfoElement(c);
+            var par = TypeWithParameter.Parameter;
+            var sut = new ParameterInfoElement(par);
 
             var actual = sut.GetHashCode();
 
-            var expected = c.GetHashCode();
+            var expected = par.GetHashCode();
             Assert.Equal(expected, actual);
         }
 

--- a/Src/Albedo.UnitTests/PropertyInfoElementTests.cs
+++ b/Src/Albedo.UnitTests/PropertyInfoElementTests.cs
@@ -78,9 +78,9 @@ namespace Ploeh.Albedo.UnitTests
         [Fact]
         public void SutEqualsOtherIdenticalInstance()
         {
-            var c = TypeWithProperty.Property;
-            var sut = new PropertyInfoElement(c);
-            var other = new PropertyInfoElement(c);
+            var pi = TypeWithProperty.Property;
+            var sut = new PropertyInfoElement(pi);
+            var other = new PropertyInfoElement(pi);
 
             var actual = sut.Equals(other);
 
@@ -119,12 +119,12 @@ namespace Ploeh.Albedo.UnitTests
         [InlineData(typeof(PropertyInfoElement))]
         public void GetHashCodeReturnsCorrectResult(Type t)
         {
-            var c = TypeWithProperty.Property;
-            var sut = new PropertyInfoElement(c);
+            var pi = TypeWithProperty.Property;
+            var sut = new PropertyInfoElement(pi);
 
             var actual = sut.GetHashCode();
 
-            var expected = c.GetHashCode();
+            var expected = pi.GetHashCode();
             Assert.Equal(expected, actual);
         }
 


### PR DESCRIPTION
Fixes naming issues Identified in #28.
