### PR TITLE
Provide syntax sugar for common queries (Accept, GetPropertiesAndFields)

### DIFF
--- a/Src/Albedo.UnitTests/Albedo.UnitTests.csproj
+++ b/Src/Albedo.UnitTests/Albedo.UnitTests.csproj
@@ -57,7 +57,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ReflectionElementExtensionsTests.cs" />
+    <Compile Include="ReflectionElementEnvyTests.cs" />
     <Compile Include="Refraction\AssemblyElementRefractionTests.cs" />
     <Compile Include="AssemblyElementTests.cs" />
     <Compile Include="CompositeReflectionElementTests.cs" />

--- a/Src/Albedo.UnitTests/ReflectionElementEnvyTests.cs
+++ b/Src/Albedo.UnitTests/ReflectionElementEnvyTests.cs
@@ -11,16 +11,13 @@ using Xunit.Extensions;
 
 namespace Ploeh.Albedo.UnitTests
 {
-    public class ReflectionElementExtensionsTests
+    public class ReflectionElementEnvyTests
     {
         [Fact]
         public void AcceptThrowsOnNullElements()
         {
-            // Fixture setup
-            IEnumerable<IReflectionElement> elements = null;
-            // Exercise system
             var e = Assert.Throws<ArgumentNullException>(() =>
-                elements.Accept(new DelegatingReflectionVisitor<object>()));
+                ReflectionElementEnvy.Accept(null, new DelegatingReflectionVisitor<object>()));
 
             Assert.Equal("elements", e.ParamName);
         }
@@ -39,7 +36,7 @@ namespace Ploeh.Albedo.UnitTests
             e1.Setup(x => x.Accept(v1)).Returns(v2);
             e2.Setup(x => x.Accept(v2)).Returns(v3);
             e3.Setup(x => x.Accept(v3)).Returns(v4);
-            
+
             var elements = new[] { e1.Object, e2.Object, e3.Object };
 
             // Exercise system
@@ -56,7 +53,7 @@ namespace Ploeh.Albedo.UnitTests
         public void GetPropertiesAndFieldsThrowsOnNullType()
         {
             var e = Assert.Throws<ArgumentNullException>(() =>
-                ReflectionElementExtensions.GetPropertiesAndFields(null, BindingFlags.Default));
+                ReflectionElementEnvy.GetPropertiesAndFields(null, BindingFlags.Default));
             Assert.Equal("type", e.ParamName);
         }
 
@@ -114,6 +111,7 @@ namespace Ploeh.Albedo.UnitTests
 
         public class TypeWithStaticAndInstanceMembers<TValue>
         {
+#pragma warning disable 414
             static TypeWithStaticAndInstanceMembers()
             {
                 PublicStaticReadOnlyProperty = default(TValue);
@@ -160,6 +158,7 @@ namespace Ploeh.Albedo.UnitTests
                 this.privateField = privateField;
             }
         }
+#pragma warning restore 414
 
     }
 }

--- a/Src/Albedo/Albedo.csproj
+++ b/Src/Albedo/Albedo.csproj
@@ -57,7 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyElement.cs" />
-    <Compile Include="ReflectionElementExtensions.cs" />
+    <Compile Include="ReflectionElementEnvy.cs" />
     <Compile Include="Refraction\CompositeReflectionElementRefraction.cs" />
     <Compile Include="Refraction\AssemblyElementRefraction.cs" />
     <Compile Include="Refraction\ConstructorInfoElementRefraction.cs" />

--- a/Src/Albedo/ReflectionElementEnvy.cs
+++ b/Src/Albedo/ReflectionElementEnvy.cs
@@ -9,7 +9,7 @@ namespace Ploeh.Albedo
     /// Contains extension methods for dealing with <see cref="IReflectionElement"/>
     /// instances, both producing and consuming them.
     /// </summary>
-    public static class ReflectionElementExtensions
+    public static class ReflectionElementEnvy
     {
         /// <summary>
         /// Accepts the <see cref="IReflectionVisitor{T}"/> visitor on each of the


### PR DESCRIPTION
This PR implements _some_ of the features discussed in #43.

These tasks are planned for this PR, introducing `ReflectionElementEnvy`:
- [x] Accept{T}(this IEnumerable{IReflectionElement}, IReflectionVisitor{T})
- [x] GetPropertiesAndFields(BindingFlags) - simplifies querying for properties and fields at the same time.
- [x] Rename `ReflectionElementExtensions` --> `ReflectionElementEnvy`
