### PR TITLE
Added ReflectionElementEnvy.GetPublicPropertiesAndFields()

### DIFF
--- a/Src/Albedo.UnitTests/ReflectionElementEnvyTests.cs
+++ b/Src/Albedo.UnitTests/ReflectionElementEnvyTests.cs
@@ -119,7 +119,7 @@ namespace Ploeh.Albedo.UnitTests
         }
 
         [Fact]
-        public void GetPublicPropertiesAndFieldsReturnsPublicStaticAndInstancePropertiesAndFields()
+        public void GetPublicPropertiesAndFieldsReturnsOnlyInstancePropertiesAndFields()
         {
             // Fixture setup
             var type = typeof(TypeWithStaticAndInstanceMembers<int>);
@@ -127,14 +127,10 @@ namespace Ploeh.Albedo.UnitTests
             var fields = new Fields<TypeWithStaticAndInstanceMembers<int>>();
             var expectedElements = new IReflectionElement[]
             {
-                new PropertyInfoElement(type.GetProperty("PublicStaticReadOnlyProperty")),
-                new PropertyInfoElement(type.GetProperty("PublicStaticProperty")),
                 new PropertyInfoElement(properties.Select(i => i.PublicReadOnlyProperty)),
                 new PropertyInfoElement(properties.Select(i => i.PublicProperty)),
                 new FieldInfoElement(fields.Select(i => i.PublicReadOnlyField)),
                 new FieldInfoElement(fields.Select(i => i.PublicField)),
-                new FieldInfoElement(type.GetField("PublicStaticField")),
-                new FieldInfoElement(type.GetField("PublicStaticReadOnlyFieldWithDefault")),
             };
 
             // Exercise system

--- a/Src/Albedo/ReflectionElementEnvy.cs
+++ b/Src/Albedo/ReflectionElementEnvy.cs
@@ -63,19 +63,17 @@ namespace Ploeh.Albedo
         }
 
         /// <summary>
-        /// Gets the public instance and public static properties and fields from the 
-        /// <paramref name="type"/>, and returns them as a sequence of 
-        /// <see cref="IReflectionElement"/> instances.
+        /// Gets the public instance properties and fields from the <paramref name="type"/>,
+        /// and returns them as a sequence of <see cref="IReflectionElement"/> instances.
         /// </summary>
         /// <param name="type">The <see cref="Type"/> which properties and fields are
         /// obtained from.</param>
         /// <returns>The sequence of <see cref="IReflectionElement"/> instances representing
-        /// the public static and public instance properties and fields from the 
+        /// the public instance properties and fields from the 
         /// <paramref name="type"/>.</returns>
         public static IEnumerable<IReflectionElement> GetPublicPropertiesAndFields(this Type type)
         {
-            return type.GetPropertiesAndFields(
-                BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance);
+            return type.GetPropertiesAndFields(BindingFlags.Public | BindingFlags.Instance);
         }
     }
 }


### PR DESCRIPTION
A convenience method for the very common scenario of querying across all an objects public properties and fields.

This implements part of #43.
