### PR TITLE
Added ReflectionElementEnvy.GetProperMethods()

### DIFF
--- a/Src/Albedo.UnitTests/ReflectionElementEnvyTests.cs
+++ b/Src/Albedo.UnitTests/ReflectionElementEnvyTests.cs
@@ -14,6 +14,34 @@ namespace Ploeh.Albedo.UnitTests
     public class ReflectionElementEnvyTests
     {
         [Fact]
+        public void GetProperMethodsThrowsOnNullType()
+        {
+            var e = Assert.Throws<ArgumentNullException>(() =>
+                ReflectionElementEnvy.GetProperMethods(null, BindingFlags.Default));
+
+            Assert.Equal("type", e.ParamName);
+        }
+
+        [Theory, ClassData(typeof(GetProperMethodsTestCases))]
+        public void GetProperMethodsReturnsMethodsExcludingPropertyAccessors(
+            Type type, BindingFlags bindingAttr, IEnumerable<IReflectionElement> expectedElements)
+        {
+            // Fixture setup
+            Func<MethodInfoElement, string> orderBy = mie => mie.MethodInfo.ToString();
+
+            // Exercise system
+            var actual = type.GetProperMethods(bindingAttr);
+
+            // Verify outcome
+            AssertUnorderedElementsEqual(
+                expectedElements,
+                actual,
+                orderBy);
+
+            // Fixture teardown
+        }
+
+        [Fact]
         public void AcceptThrowsOnNullElements()
         {
             var e = Assert.Throws<ArgumentNullException>(() =>
@@ -65,6 +93,59 @@ namespace Ploeh.Albedo.UnitTests
             Assert.Equal(expectedElements, actual);
         }
 
+        static void AssertUnorderedElementsEqual<TConcreteElement, TKey>(
+            IEnumerable<IReflectionElement> expected,
+            IEnumerable<IReflectionElement> actual,
+            Func<TConcreteElement, TKey> orderBy)
+        {
+            Assert.Equal(
+                expected.Cast<TConcreteElement>().OrderBy(orderBy),
+                actual.Cast<TConcreteElement>().OrderBy(orderBy));
+        }
+
+        private class GetProperMethodsTestCases : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                var type = typeof(TypeWithStaticAndInstanceMembers<int>);
+                var methods = new Methods<TypeWithStaticAndInstanceMembers<int>>(); 
+
+                yield return new object[]
+                {
+                    type,
+                    BindingFlags.Public | BindingFlags.Instance,
+                    new IReflectionElement[]
+                    {
+                        new MethodInfoElement(methods.Select(t => t.PublicMethod())),
+                        new MethodInfoElement(type.GetMethod("ToString")),
+                        new MethodInfoElement(type.GetMethod("Equals")),
+                        new MethodInfoElement(type.GetMethod("GetHashCode")),
+                        new MethodInfoElement(type.GetMethod("GetType")),
+                    }
+                };
+
+                yield return new object[]
+                {
+                    type,
+                    BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static,
+                    new IReflectionElement[]
+                    {
+                        new MethodInfoElement(methods.Select(t => t.PublicMethod())),
+                        new MethodInfoElement(type.GetMethod("PublicStaticVoidMethod")),
+                        new MethodInfoElement(type.GetMethod("ToString")),
+                        new MethodInfoElement(type.GetMethod("Equals")),
+                        new MethodInfoElement(type.GetMethod("GetHashCode")),
+                        new MethodInfoElement(type.GetMethod("GetType")),
+                    }
+                };
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+
         private class GetPropertiesAndFieldsTestCases : IEnumerable<object[]>
         {
             public IEnumerator<object[]> GetEnumerator()
@@ -111,6 +192,41 @@ namespace Ploeh.Albedo.UnitTests
 
         public class TypeWithStaticAndInstanceMembers<TValue>
         {
+            public static TValue PublicStaticVoidMethod()
+            {
+                return default(TValue);
+            }
+
+            internal static TValue InternalStaticMethod()
+            {
+                return default(TValue);
+            }
+
+            protected static TValue ProtectedStaticMethod()
+            {
+                return default(TValue);
+            }
+
+            public TValue PublicMethod()
+            {
+                return default(TValue);
+            }
+
+            protected internal TValue ProtectedInternalMethod()
+            {
+                return default(TValue);
+            }
+
+            protected virtual TValue ProtectedVirtualMethod()
+            {
+                return default(TValue);
+            }
+
+            internal virtual TValue InternalVirtualMethod()
+            {
+                return default(TValue);
+            }
+
 #pragma warning disable 414
             static TypeWithStaticAndInstanceMembers()
             {

--- a/Src/Albedo/ReflectionElementEnvy.cs
+++ b/Src/Albedo/ReflectionElementEnvy.cs
@@ -12,6 +12,30 @@ namespace Ploeh.Albedo
     public static class ReflectionElementEnvy
     {
         /// <summary>
+        /// Gets 'proper' methods from the <paramref name="type"/>; that is, methods excluding
+        /// property accessors, and matching the provided <paramref name="bindingAttr"/>.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> from which methods are selected</param>
+        /// <param name="bindingAttr">The <see cref="BindingFlags"/> used to determine which
+        /// methods to return.</param>
+        /// <returns>The sequence of <see cref="IReflectionElement"/> instances representing
+        /// the matching methods found on the <paramref name="type"/>.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly",
+           MessageId = "Attr", Justification = "This is the standard naming pattern for a BindingFlags parameter, used in the .NET Framework.")]
+        public static IEnumerable<IReflectionElement> GetProperMethods(
+            this Type type, BindingFlags bindingAttr)
+        {
+            if (type == null) throw new ArgumentNullException("type");
+            return type
+                .GetMethods(bindingAttr)
+                .Except(type
+                    .GetProperties()
+                    .SelectMany(pi => pi.GetAccessors()))
+                .Select(mi => new MethodInfoElement(mi))
+                .Cast<IReflectionElement>();
+        }
+
+        /// <summary>
         /// Accepts the <see cref="IReflectionVisitor{T}"/> visitor on each of the
         /// <paramref name="elements"/> in the sequence.
         /// </summary>


### PR DESCRIPTION
providing a more consistent way to perform the common query: methods, excluding property accessors.

Note this time around, I've assumed no guarantee about the order in which reflection will return the underlying elements.

This implements part of #43.
