### PR TITLE
Introduced `ToString` overrides for reflection elements,

### DIFF
--- a/Src/Albedo/AssemblyElement.cs
+++ b/Src/Albedo/AssemblyElement.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Reflection;
 
 namespace Ploeh.Albedo
@@ -86,7 +87,8 @@ namespace Ploeh.Albedo
         /// <see cref="Assembly"/></returns>
         public override string ToString()
         {
-            return string.Format("[[{0}]] ({1})", this.Assembly, "assembly");
+            return string.Format(
+                CultureInfo.CurrentCulture, "[[{0}]] ({1})", this.Assembly, "assembly");
         }
     }
 }

--- a/Src/Albedo/ConstructorInfoElement.cs
+++ b/Src/Albedo/ConstructorInfoElement.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 
@@ -89,7 +90,8 @@ namespace Ploeh.Albedo
         /// <see cref="ConstructorInfo"/></returns>
         public override string ToString()
         {
-            return string.Format("[[{0}]] ({1})", this.ConstructorInfo, "constructor");
+            return string.Format(
+                CultureInfo.CurrentCulture, "[[{0}]] ({1})", this.ConstructorInfo, "constructor");
         }
     }
 }

--- a/Src/Albedo/EventInfoElement.cs
+++ b/Src/Albedo/EventInfoElement.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Reflection;
 
 namespace Ploeh.Albedo
@@ -88,7 +89,8 @@ namespace Ploeh.Albedo
         /// <see cref="EventInfo"/></returns>
         public override string ToString()
         {
-            return string.Format("[[{0}]] ({1})", this.EventInfo, "event");
+            return string.Format(
+                CultureInfo.CurrentCulture, "[[{0}]] ({1})", this.EventInfo, "event");
         }
     }
 }

--- a/Src/Albedo/FieldInfoElement.cs
+++ b/Src/Albedo/FieldInfoElement.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Reflection;
 
 namespace Ploeh.Albedo
@@ -88,7 +89,8 @@ namespace Ploeh.Albedo
         /// <see cref="FieldInfo"/></returns>
         public override string ToString()
         {
-            return string.Format("[[{0}]] ({1})", this.FieldInfo, "field");
+            return string.Format(
+                CultureInfo.CurrentCulture, "[[{0}]] ({1})", this.FieldInfo, "field");
         }
     }
 }

--- a/Src/Albedo/LocalVariableInfoElement.cs
+++ b/Src/Albedo/LocalVariableInfoElement.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Reflection;
 
 namespace Ploeh.Albedo
@@ -88,7 +89,8 @@ namespace Ploeh.Albedo
         /// <see cref="LocalVariableInfo"/></returns>
         public override string ToString()
         {
-            return string.Format("[[{0}]] ({1})", this.LocalVariableInfo, "local");
+            return string.Format(
+                CultureInfo.CurrentCulture, "[[{0}]] ({1})", this.LocalVariableInfo, "local");
         }
     }
 }

--- a/Src/Albedo/MethodInfoElement.cs
+++ b/Src/Albedo/MethodInfoElement.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 
@@ -89,7 +90,8 @@ namespace Ploeh.Albedo
         /// <see cref="MethodInfo"/></returns>
         public override string ToString()
         {
-            return string.Format("[[{0}]] ({1})", this.MethodInfo, "method");
+            return string.Format(
+                CultureInfo.CurrentCulture, "[[{0}]] ({1})", this.MethodInfo, "method");
         }
     }
 }

--- a/Src/Albedo/ParameterInfoElement.cs
+++ b/Src/Albedo/ParameterInfoElement.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Reflection;
 
 namespace Ploeh.Albedo
@@ -88,7 +89,8 @@ namespace Ploeh.Albedo
         /// <see cref="ParameterInfo"/></returns>
         public override string ToString()
         {
-            return string.Format("[[{0}]] ({1})", this.ParameterInfo, "parameter");
+            return string.Format(
+                CultureInfo.CurrentCulture, "[[{0}]] ({1})", this.ParameterInfo, "parameter");
         }
     }
 }

--- a/Src/Albedo/PropertyInfoElement.cs
+++ b/Src/Albedo/PropertyInfoElement.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Reflection;
 
 namespace Ploeh.Albedo
@@ -88,7 +89,8 @@ namespace Ploeh.Albedo
         /// <see cref="PropertyInfo"/></returns>
         public override string ToString()
         {
-            return string.Format("[[{0}]] ({1})", this.PropertyInfo, "property");
+            return string.Format(
+                CultureInfo.CurrentCulture, "[[{0}]] ({1})", this.PropertyInfo, "property");
         }
     }
 }

--- a/Src/Albedo/TypeElement.cs
+++ b/Src/Albedo/TypeElement.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 
 namespace Ploeh.Albedo
@@ -88,7 +89,8 @@ namespace Ploeh.Albedo
         /// <see cref="Type"/></returns>
         public override string ToString()
         {
-            return string.Format("[[{0}]] ({1})", this.Type, "type");
+            return string.Format(
+                CultureInfo.CurrentCulture, "[[{0}]] ({1})", this.Type, "type");
         }
     }
 }


### PR DESCRIPTION
In order to provide a better debugging experience.

This implements #53.

The following is a summary of the proposed changes.

``` csharp
new object [] {
    Assembly.GetExecutingAssembly(),
    typeof(TimeSpan),
    typeof(TimeSpan).GetConstructor(new Type[] { typeof(long) }), // .ctor(long ticks)
    typeof(Assembly).GetEvent("ModuleResolve"),
    typeof(string).GetField("Empty"),
    typeof(Exception).GetMethod("GetObjectData").GetMethodBody().LocalVariables[0],
    typeof(object).GetMethod("Equals", new[] { typeof(object)}).GetParameters()[0],
    typeof(string).GetProperty("Chars"),
}
.Select(o => o.ToReflectionElement())
.Select(e => new { Type = e.GetType(), ToString = e.ToString() })
```

Produces the following output:

<div><div class="spacer"><table id="t1"><tr><th>Type</th><th>ToString</th></tr><tr><td>AssemblyElement</td><td>[[query_idbiin, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]] (assembly)</td></tr><tr><td>TypeElement</td><td>[[System.TimeSpan]] (type)</td></tr><tr><td>ConstructorInfoElement</td><td>[[Void .ctor(Int64)]] (constructor)</td></tr><tr><td>EventInfoElement</td><td>[[System.Reflection.ModuleResolveEventHandler ModuleResolve]] (event)</td></tr><tr><td>FieldInfoElement</td><td>[[System.String Empty]] (field)</td></tr><tr><td>LocalVariableInfoElement</td><td>[[System.String (0)]] (local)</td></tr><tr><td>ParameterInfoElement</td><td>[[System.Object obj]] (parameter)</td></tr><tr><td>PropertyInfoElement</td><td>[[Char Chars [Int32]]] (property)</td></tr><tr><td>TypeElement</td><td>[[System.String]] (type)</td></tr></table></div></div>
