### PR TITLE
Updated defaults for GetProperMethods() and GetPublicPropertiesAndFields()

### DIFF
--- a/Src/Albedo.UnitTests/ReflectionElementEnvyTests.cs
+++ b/Src/Albedo.UnitTests/ReflectionElementEnvyTests.cs
@@ -14,7 +14,7 @@ namespace Ploeh.Albedo.UnitTests
     public class ReflectionElementEnvyTests
     {
         [Fact]
-        public void GetProperMethodsThrowsOnNullType()
+        public void GetProperMethodsWithBindingFlagsThrowsOnNullType()
         {
             var e = Assert.Throws<ArgumentNullException>(() =>
                 ReflectionElementEnvy.GetProperMethods(null, BindingFlags.Default));
@@ -22,8 +22,47 @@ namespace Ploeh.Albedo.UnitTests
             Assert.Equal("type", e.ParamName);
         }
 
+        [Fact]
+        public void GetProperMethodsThrowsOnNullType()
+        {
+            var e = Assert.Throws<ArgumentNullException>(() =>
+                ReflectionElementEnvy.GetProperMethods(null));
+
+            Assert.Equal("type", e.ParamName);
+        }
+
+        [Fact]
+        public void GetProperMethodsReturnsPublicStaticAndPublicInstanceProperMethods()
+        {
+            // Fixture setup
+            Func<MethodInfoElement, string> orderBy = mie => mie.MethodInfo.ToString();
+
+            var type = typeof(TypeWithStaticAndInstanceMembers<int>);
+            var methods = new Methods<TypeWithStaticAndInstanceMembers<int>>();
+            var expected = new IReflectionElement[]
+            {
+                new MethodInfoElement(methods.Select(t => t.PublicMethod())),
+                new MethodInfoElement(type.GetMethod("PublicStaticVoidMethod")),
+                new MethodInfoElement(type.GetMethod("ToString")),
+                new MethodInfoElement(type.GetMethod("Equals")),
+                new MethodInfoElement(type.GetMethod("GetHashCode")),
+                new MethodInfoElement(type.GetMethod("GetType")),
+            };
+
+            // Exercise system
+            var actual = type.GetProperMethods();
+
+            // Verify outcome
+            AssertUnorderedElementsEqual(
+                expected,
+                actual,
+                orderBy);
+
+            // Fixture teardown
+        }
+
         [Theory, ClassData(typeof(GetProperMethodsTestCases))]
-        public void GetProperMethodsReturnsMethodsExcludingPropertyAccessors(
+        public void GetProperMethodsWithBindingFlagsReturnsMethodsExcludingPropertyAccessors(
             Type type, BindingFlags bindingAttr, IEnumerable<IReflectionElement> expectedElements)
         {
             // Fixture setup

--- a/Src/Albedo/ReflectionElementEnvy.cs
+++ b/Src/Albedo/ReflectionElementEnvy.cs
@@ -36,6 +36,19 @@ namespace Ploeh.Albedo
         }
 
         /// <summary>
+        /// Gets 'proper' methods from the <paramref name="type"/>; that is, methods excluding
+        /// property accessors. Public | Static | Instance methods are returned.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> from which methods are selected</param>
+        /// <returns>The sequence of <see cref="IReflectionElement"/> instances representing
+        /// the public static or public instance methods on the <paramref name="type"/>.</returns>
+        public static IEnumerable<IReflectionElement> GetProperMethods(this Type type)
+        {
+            return type.GetProperMethods(
+                BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance);
+        }
+
+        /// <summary>
         /// Accepts the <see cref="IReflectionVisitor{T}"/> visitor on each of the
         /// <paramref name="elements"/> in the sequence.
         /// </summary>


### PR DESCRIPTION
As per [this discussion](https://github.com/ploeh/Albedo/issues/43#issuecomment-31387646) in #43.
