### PR TITLE
Added tests to exercise the selection of generic methods

### DIFF
--- a/Src/Albedo.UnitTests/MethodsTests.cs
+++ b/Src/Albedo.UnitTests/MethodsTests.cs
@@ -122,6 +122,7 @@ namespace Ploeh.Albedo.UnitTests
         {
             var sut = new Methods<ClassWithMethods>();
             var dummy = default(T);
+
             MethodInfo actual = sut.Select(x => x.IncludeParameters<T>(dummy));
 
             var expected =
@@ -209,6 +210,7 @@ namespace Ploeh.Albedo.UnitTests
         {
             var sut = new Methods<ClassWithMethods<T>>();
             var dummy = default(T);
+
             MethodInfo actual = sut.Select(x => x.IncludeParameters<T>(dummy));
 
             var expected =
@@ -252,6 +254,7 @@ namespace Ploeh.Albedo.UnitTests
         {
             var sut = new Methods<ClassWithMethods<T>>();
             var dummy = default(T);
+
             var actual = from x in sut select x.IncludeParameters<T>(dummy);
 
             var expected =


### PR DESCRIPTION
Added tests to `Methods<T>` class in order to exercise the selection of:
- non-generic types containing
  - generic methods
  - generic methods with return value
- generic types containing
  - generic methods
  - generic methods with return value

This should address #68.
