### PR TITLE
Methods.Select allows non static calls.

### DIFF
--- a/Src/Albedo.UnitTests/MethodsTests.cs
+++ b/Src/Albedo.UnitTests/MethodsTests.cs
@@ -385,12 +385,6 @@ namespace Ploeh.Albedo.UnitTests
         }
 
         [Fact]
-        public void SelectCallThrows()
-        {
-            Assert.Throws<ArgumentException>(() => Methods.Select(() => this.SelectCallThrows()));
-        }
-
-        [Fact]
         public void SelectInheritedStaticMethodReturnsCorrectMethod()
         {
             var expected = typeof(ClassWithStaticMethods).GetMethod("StaticNonVoidMethod");

--- a/Src/Albedo/Methods.cs
+++ b/Src/Albedo/Methods.cs
@@ -246,14 +246,7 @@ namespace Ploeh.Albedo
                 throw new ArgumentException("The expression's body must be a MethodCallExpression. The code block supplied should invoke a method.\nExample: x => x.Foo().", "methodSelector");
             }
 
-            if (methodCallExp.Object != null)
-            {
-                throw new ArgumentException("Only static calls are allowed. The code block supplied should invoke a static method.\nExample: () => BarStaticClass.Foo()." +
-                    " For non static methods see Methods<T>.", "methodSelector");
-            }
-
-            var method = methodCallExp.Method;
-            return method;
+            return methodCallExp.Method;
         }
     }
 }


### PR DESCRIPTION
Fields.Select and Properties.Select allow such behavior already,
so this is made for sake of consistency.
