### PR TITLE
Static Constructors

### DIFF
--- a/Src/Albedo.UnitTests/ConstructorsTest.cs
+++ b/Src/Albedo.UnitTests/ConstructorsTest.cs
@@ -10,9 +10,7 @@ namespace Ploeh.Albedo.UnitTests
         public void SelectReturnsCorrectConstructor()
         {
             var expected = TypeWithCtors.Ctor;
-
             var actual = Constructors.Select(() => new TypeWithCtors());
-
             Assert.Equal(expected, actual);
         }
 

--- a/Src/Albedo/Constructors.cs
+++ b/Src/Albedo/Constructors.cs
@@ -67,11 +67,7 @@ namespace Ploeh.Albedo
             var newExpression = constructorSelector.Body as NewExpression;
             if (newExpression == null)
             {
-                throw new ArgumentException(
-                    "The expression's body must be a NewExpression. " +
-                        "The code block supplied should construct an new instance.\n" +
-                        "Example: () => new Foo().",
-                    "constructorSelector");
+                throw new ArgumentException("The expression's body must be a NewExpression. The code block supplied should construct an new instance.\nExample: () => new Foo().", "constructorSelector");
             }
 
             return newExpression.Constructor;


### PR DESCRIPTION
Closes #81

This PR contains some breaking-changes.
- Delete: `Select<T>(Expression<Func<object, T>>)`
- Before: `public ConstructorInfo Select<T>(Expression<Func<T>>)`  
  After   : `public static ConstructorInfo Select<T>(Expression<Func<T>>)`
