### PR TITLE
Remove the "Phoeh" namespace and assembly name prefix

### DIFF
--- a/Src/Albedo.UnitTests/Albedo.UnitTests.csproj
+++ b/Src/Albedo.UnitTests/Albedo.UnitTests.csproj
@@ -1,9 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
-
-    <AssemblyName>Ploeh.Albedo.UnitTests</AssemblyName>
-    <RootNamespace>Ploeh.Albedo.UnitTests</RootNamespace>
+    <AssemblyName>Albedo.UnitTests</AssemblyName>
 
     <Configurations>Debug;Release;Verify</Configurations>
 

--- a/Src/Albedo.UnitTests/AssemblyElementTests.cs
+++ b/Src/Albedo.UnitTests/AssemblyElementTests.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Xunit;
-using Xunit.Extensions;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     public class AssemblyElementTest
     {

--- a/Src/Albedo.UnitTests/CompositeReflectionElementTests.cs
+++ b/Src/Albedo.UnitTests/CompositeReflectionElementTests.cs
@@ -1,12 +1,10 @@
-using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using Moq;
 using Xunit;
-using Xunit.Extensions;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     public class CompositeReflectionElementTests
     {

--- a/Src/Albedo.UnitTests/ConcreteElementConversionsTests.cs
+++ b/Src/Albedo.UnitTests/ConcreteElementConversionsTests.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using Xunit;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     public class ConcreteElementConversionsTests
     {

--- a/Src/Albedo.UnitTests/ConstructorInfoElementTests.cs
+++ b/Src/Albedo.UnitTests/ConstructorInfoElementTests.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Xunit;
-using Xunit.Extensions;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     public class ConstructorInfoElementTests
     {

--- a/Src/Albedo.UnitTests/ConstructorsTest.cs
+++ b/Src/Albedo.UnitTests/ConstructorsTest.cs
@@ -2,7 +2,7 @@
 using System.Linq.Expressions;
 using Xunit;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     public class ConstructorsTest
     {

--- a/Src/Albedo.UnitTests/DelegatingReflectionVisitor.cs
+++ b/Src/Albedo.UnitTests/DelegatingReflectionVisitor.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     internal class DelegatingReflectionVisitor<T> : IReflectionVisitor<T>
     {

--- a/Src/Albedo.UnitTests/EventInfoElementTests.cs
+++ b/Src/Albedo.UnitTests/EventInfoElementTests.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Xunit;
-using Xunit.Extensions;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     public class EventInfoElementTests
     {

--- a/Src/Albedo.UnitTests/FieldInfoElementTests.cs
+++ b/Src/Albedo.UnitTests/FieldInfoElementTests.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Xunit;
-using Xunit.Extensions;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     public class FieldInfoElementTests
     {

--- a/Src/Albedo.UnitTests/FieldsTests.cs
+++ b/Src/Albedo.UnitTests/FieldsTests.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using Xunit;
 using System.Reflection;
+using Xunit;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     public class FieldsTests
     {

--- a/Src/Albedo.UnitTests/LocalVariableInfoElementTests.cs
+++ b/Src/Albedo.UnitTests/LocalVariableInfoElementTests.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Xunit;
-using Xunit.Extensions;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     public class LocalVariableInfoElementTests
     {

--- a/Src/Albedo.UnitTests/MethodInfoElementTests.cs
+++ b/Src/Albedo.UnitTests/MethodInfoElementTests.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Xunit;
-using Xunit.Extensions;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     public class MethodInfoElementTests
     {

--- a/Src/Albedo.UnitTests/MethodsTests.cs
+++ b/Src/Albedo.UnitTests/MethodsTests.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Linq;
 using System.Linq.Expressions;
-using Xunit;
 using System.Reflection;
+using Xunit;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     public abstract class MethodsTests<T>
     {

--- a/Src/Albedo.UnitTests/NullReflectionElementTests.cs
+++ b/Src/Albedo.UnitTests/NullReflectionElementTests.cs
@@ -1,13 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Xunit;
-using Ploeh.Albedo;
 using Moq;
-using Xunit.Extensions;
+using Xunit;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     public class NullReflectionElementTests
     {

--- a/Src/Albedo.UnitTests/ParameterInfoElementTests.cs
+++ b/Src/Albedo.UnitTests/ParameterInfoElementTests.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Reflection;
 using Xunit;
-using Xunit.Extensions;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     public class ParameterInfoElementTests
     {

--- a/Src/Albedo.UnitTests/PropertiesTests.cs
+++ b/Src/Albedo.UnitTests/PropertiesTests.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using Xunit;
 using System.Reflection;
+using Xunit;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     public class PropertiesTests
     {

--- a/Src/Albedo.UnitTests/PropertyInfoElementTests.cs
+++ b/Src/Albedo.UnitTests/PropertyInfoElementTests.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Xunit;
-using Xunit.Extensions;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     public class PropertyInfoElementTests
     {

--- a/Src/Albedo.UnitTests/ReflectionElementEnvyTests.cs
+++ b/Src/Albedo.UnitTests/ReflectionElementEnvyTests.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using Moq;
 using Xunit;
-using Xunit.Extensions;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     public class ReflectionElementEnvyTests
     {

--- a/Src/Albedo.UnitTests/ReflectionVisitorTests.cs
+++ b/Src/Albedo.UnitTests/ReflectionVisitorTests.cs
@@ -6,7 +6,7 @@ using Moq;
 using Xunit;
 using Xunit.Sdk;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     public abstract class ReflectionVisitorTests<T>
     {

--- a/Src/Albedo.UnitTests/Refraction/AsReflectionElementTests.cs
+++ b/Src/Albedo.UnitTests/Refraction/AsReflectionElementTests.cs
@@ -2,11 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
+using Albedo.Refraction;
 using Moq;
 using Xunit;
 
-namespace Ploeh.Albedo.Refraction.UnitTests
+namespace Albedo.UnitTests.Refraction
 {
     public class AsReflectionElementTests
     {

--- a/Src/Albedo.UnitTests/Refraction/AssemblyElementRefractionTests.cs
+++ b/Src/Albedo.UnitTests/Refraction/AssemblyElementRefractionTests.cs
@@ -1,15 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Xunit;
-using Ploeh.Albedo;
-using Ploeh.Albedo.UnitTests;
-using Xunit.Extensions;
-using Moq;
 using System.Reflection;
+using Albedo.Refraction;
+using Xunit;
 
-namespace Ploeh.Albedo.Refraction.UnitTests
+namespace Albedo.UnitTests.Refraction
 {
     public class AssemblyElementRefractionTests
     {

--- a/Src/Albedo.UnitTests/Refraction/CompositeReflectionElementRefractionTests.cs
+++ b/Src/Albedo.UnitTests/Refraction/CompositeReflectionElementRefractionTests.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Xunit;
-using Ploeh.Albedo;
+using Albedo.Refraction;
 using Moq;
+using Xunit;
 
-namespace Ploeh.Albedo.Refraction.UnitTests
+namespace Albedo.UnitTests.Refraction
 {
     public class CompositeReflectionElementRefractionTests
     {

--- a/Src/Albedo.UnitTests/Refraction/ConstructorInfoElementRefractionTests.cs
+++ b/Src/Albedo.UnitTests/Refraction/ConstructorInfoElementRefractionTests.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Xunit;
-using Ploeh.Albedo;
-using Xunit.Extensions;
 using System.Reflection;
+using Albedo.Refraction;
+using Xunit;
 
-namespace Ploeh.Albedo.Refraction.UnitTests
+namespace Albedo.UnitTests.Refraction
 {
     public class ConstructorInfoElementRefractionTests
     {

--- a/Src/Albedo.UnitTests/Refraction/EventInfoElementRefractionTests.cs
+++ b/Src/Albedo.UnitTests/Refraction/EventInfoElementRefractionTests.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Xunit;
-using Ploeh.Albedo;
-using Xunit.Extensions;
 using System.Reflection;
+using Albedo.Refraction;
+using Xunit;
 
-namespace Ploeh.Albedo.Refraction.UnitTests
+namespace Albedo.UnitTests.Refraction
 {
     public class EventInfoElementRefractionTests
     {

--- a/Src/Albedo.UnitTests/Refraction/FieldInfoElementRefractionTests.cs
+++ b/Src/Albedo.UnitTests/Refraction/FieldInfoElementRefractionTests.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Xunit;
-using Ploeh.Albedo;
-using Xunit.Extensions;
 using System.Reflection;
+using Albedo.Refraction;
+using Xunit;
 
-namespace Ploeh.Albedo.Refraction.UnitTests
+namespace Albedo.UnitTests.Refraction
 {
     public class FieldInfoElementRefractionTests
     {

--- a/Src/Albedo.UnitTests/Refraction/LocalVariableInfoElementRefractionTests.cs
+++ b/Src/Albedo.UnitTests/Refraction/LocalVariableInfoElementRefractionTests.cs
@@ -3,10 +3,10 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Albedo.Refraction;
 using Xunit;
-using Xunit.Extensions;
 
-namespace Ploeh.Albedo.Refraction.UnitTests
+namespace Albedo.UnitTests.Refraction
 {
     public class LocalVariableInfoElementRefractionTests
     {

--- a/Src/Albedo.UnitTests/Refraction/MethodInfoElementRefractionTests.cs
+++ b/Src/Albedo.UnitTests/Refraction/MethodInfoElementRefractionTests.cs
@@ -1,13 +1,11 @@
-﻿using Ploeh.Albedo;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
+using Albedo.Refraction;
 using Xunit;
-using Xunit.Extensions;
 
-namespace Ploeh.Albedo.Refraction.UnitTests
+namespace Albedo.UnitTests.Refraction
 {
     public class MethodInfoElementRefractionTests
     {

--- a/Src/Albedo.UnitTests/Refraction/ParameterInfoElementRefractionTests.cs
+++ b/Src/Albedo.UnitTests/Refraction/ParameterInfoElementRefractionTests.cs
@@ -1,13 +1,11 @@
-﻿using Ploeh.Albedo;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
+using Albedo.Refraction;
 using Xunit;
-using Xunit.Extensions;
 
-namespace Ploeh.Albedo.Refraction.UnitTests
+namespace Albedo.UnitTests.Refraction
 {
     public class ParameterInfoElementRefractionTests
     {

--- a/Src/Albedo.UnitTests/Refraction/PropertyInfoElementRefractionTests.cs
+++ b/Src/Albedo.UnitTests/Refraction/PropertyInfoElementRefractionTests.cs
@@ -1,13 +1,11 @@
-﻿using Ploeh.Albedo;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
+using Albedo.Refraction;
 using Xunit;
-using Xunit.Extensions;
 
-namespace Ploeh.Albedo.Refraction.UnitTests
+namespace Albedo.UnitTests.Refraction
 {
     public class PropertyInfoElementRefractionTests
     {

--- a/Src/Albedo.UnitTests/Refraction/ReflectionElementRefractionTests.cs
+++ b/Src/Albedo.UnitTests/Refraction/ReflectionElementRefractionTests.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Xunit;
-using Ploeh.Albedo.Refraction;
-using Xunit.Extensions;
+using Albedo.Refraction;
 using Moq;
+using Xunit;
 
-namespace Ploeh.Albedo.Refraction.UnitTests
+namespace Albedo.UnitTests.Refraction
 {
     public class ReflectionElementRefractionTests
     {

--- a/Src/Albedo.UnitTests/Refraction/ToReflectionElementTests.cs
+++ b/Src/Albedo.UnitTests/Refraction/ToReflectionElementTests.cs
@@ -2,12 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
+using Albedo.Refraction;
 using Moq;
 using Xunit;
-using Xunit.Extensions;
 
-namespace Ploeh.Albedo.Refraction.UnitTests
+namespace Albedo.UnitTests.Refraction
 {
     public class ToReflectionElementTests
     {

--- a/Src/Albedo.UnitTests/Refraction/TypeElementRefractionTests.cs
+++ b/Src/Albedo.UnitTests/Refraction/TypeElementRefractionTests.cs
@@ -1,13 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using Albedo.Refraction;
 using Xunit;
-using Ploeh.Albedo;
-using Ploeh.Albedo.UnitTests;
-using Xunit.Extensions;
 
-namespace Ploeh.Albedo.Refraction.UnitTests
+namespace Albedo.UnitTests.Refraction
 {
     public class TypeElementRefractionTests
     {

--- a/Src/Albedo.UnitTests/Samples/SemanticComparison/SemanticComparisonValue.cs
+++ b/Src/Albedo.UnitTests/Samples/SemanticComparison/SemanticComparisonValue.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
-namespace Ploeh.Albedo.UnitTests.Samples.SemanticComparison
+namespace Albedo.UnitTests.Samples.SemanticComparison
 {
     public class SemanticComparisonValue
     {

--- a/Src/Albedo.UnitTests/Samples/SemanticComparison/SemanticElementComparer.cs
+++ b/Src/Albedo.UnitTests/Samples/SemanticComparison/SemanticElementComparer.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
-namespace Ploeh.Albedo.UnitTests.Samples.SemanticComparison
+namespace Albedo.UnitTests.Samples.SemanticComparison
 {
     public class SemanticElementComparer : IEqualityComparer<IReflectionElement>
     {

--- a/Src/Albedo.UnitTests/Samples/SemanticComparison/SemanticReflectionVisitor.cs
+++ b/Src/Albedo.UnitTests/Samples/SemanticComparison/SemanticReflectionVisitor.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections;
 using System.Linq;
-using System.Text;
 
-namespace Ploeh.Albedo.UnitTests.Samples.SemanticComparison
+namespace Albedo.UnitTests.Samples.SemanticComparison
 {
     public class SemanticReflectionVisitor : ReflectionVisitor<IEnumerable>
     {

--- a/Src/Albedo.UnitTests/Samples/ValueWriting/ClassWithWritablePropertiesAndFields.cs
+++ b/Src/Albedo.UnitTests/Samples/ValueWriting/ClassWithWritablePropertiesAndFields.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Ploeh.Albedo.UnitTests.Samples.ValueWriting
+﻿namespace Albedo.UnitTests.Samples.ValueWriting
 {
     public class ClassWithWritablePropertiesAndFields<T>
     {

--- a/Src/Albedo.UnitTests/Samples/ValueWriting/ValueWritingVisitor.cs
+++ b/Src/Albedo.UnitTests/Samples/ValueWriting/ValueWritingVisitor.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
-namespace Ploeh.Albedo.UnitTests.Samples.ValueWriting
+namespace Albedo.UnitTests.Samples.ValueWriting
 {
     public class ValueWritingVisitor : ReflectionVisitor<Action<object>>
     {

--- a/Src/Albedo.UnitTests/Scenario.cs
+++ b/Src/Albedo.UnitTests/Scenario.cs
@@ -1,14 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
+using Albedo.UnitTests.Samples.SemanticComparison;
+using Albedo.UnitTests.Samples.ValueWriting;
 using Xunit;
-using Xunit.Extensions;
-using Ploeh.Albedo.UnitTests.Samples.SemanticComparison;
-using Ploeh.Albedo.UnitTests.Samples.ValueWriting;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     public class Scenario
     {

--- a/Src/Albedo.UnitTests/TypeElementTests.cs
+++ b/Src/Albedo.UnitTests/TypeElementTests.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using Xunit;
-using Xunit.Extensions;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     public class TypeElementTests
     {

--- a/Src/Albedo.UnitTests/TypeWithCtors.cs
+++ b/Src/Albedo.UnitTests/TypeWithCtors.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     internal class TypeWithCtors
     {

--- a/Src/Albedo.UnitTests/TypeWithEvents.cs
+++ b/Src/Albedo.UnitTests/TypeWithEvents.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Reflection;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     internal class TypeWithEvents
     {

--- a/Src/Albedo.UnitTests/TypeWithFields.cs
+++ b/Src/Albedo.UnitTests/TypeWithFields.cs
@@ -1,6 +1,6 @@
 using System.Reflection;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     internal class TypeWithFields
     {

--- a/Src/Albedo.UnitTests/TypeWithLocalVariables.cs
+++ b/Src/Albedo.UnitTests/TypeWithLocalVariables.cs
@@ -1,6 +1,6 @@
 ﻿using System.Reflection;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     internal class TypeWithLocalVariables
     {

--- a/Src/Albedo.UnitTests/TypeWithMethods.cs
+++ b/Src/Albedo.UnitTests/TypeWithMethods.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     internal class TypeWithMethods
     {

--- a/Src/Albedo.UnitTests/TypeWithParameters.cs
+++ b/Src/Albedo.UnitTests/TypeWithParameters.cs
@@ -1,7 +1,7 @@
 using System.Linq;
 using System.Reflection;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     internal class TypeWithParameters
     {

--- a/Src/Albedo.UnitTests/TypeWithProperties.cs
+++ b/Src/Albedo.UnitTests/TypeWithProperties.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Reflection;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     internal class TypeWithProperties
     {

--- a/Src/Albedo.UnitTests/ValueCollectingVisitorTests.cs
+++ b/Src/Albedo.UnitTests/ValueCollectingVisitorTests.cs
@@ -3,11 +3,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Ploeh.Albedo.Refraction;
 using Xunit;
-using Xunit.Extensions;
 
-namespace Ploeh.Albedo.UnitTests
+namespace Albedo.UnitTests
 {
     public class ValueCollectingVisitorTests
     {

--- a/Src/Albedo/Albedo.csproj
+++ b/Src/Albedo/Albedo.csproj
@@ -1,9 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net35;netstandard2.0</TargetFrameworks>
-
-    <AssemblyName>Ploeh.Albedo</AssemblyName>
-    <RootNamespace>Ploeh.Albedo</RootNamespace>
+    <AssemblyName>Albedo</AssemblyName>
 
     <CodeAnalysisCulture>en-US</CodeAnalysisCulture>
     <CodeAnalysisRuleSet>Albedo.ruleset</CodeAnalysisRuleSet>
@@ -41,7 +39,4 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <ItemGroup>
-    <CodeAnalysisDictionary Include="CodeAnalysisDictionary.xml" />
-  </ItemGroup>
 </Project>

--- a/Src/Albedo/AssemblyElement.cs
+++ b/Src/Albedo/AssemblyElement.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 
-namespace Ploeh.Albedo
+namespace Albedo
 {
     /// <summary>
     /// An <see cref="IReflectionElement"/> representing an <see cref="Assembly"/> which
@@ -29,7 +29,7 @@ namespace Ploeh.Albedo
 
         /// <summary>
         /// Accepts the provided <see cref="IReflectionVisitor{T}"/>, by calling the
-        /// appropriate strongly-typed <see cref="IReflectionVisitor{T}.Visit(Ploeh.Albedo.AssemblyElement)"/>
+        /// appropriate strongly-typed <see cref="IReflectionVisitor{T}.Visit(Albedo.AssemblyElement)"/>
         /// method on the visitor.
         /// </summary>
         /// <typeparam name="T">The type of observation or result which the

--- a/Src/Albedo/CodeAnalysisDictionary.xml
+++ b/Src/Albedo/CodeAnalysisDictionary.xml
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<Dictionary>
-  <Words>
-    <Recognized>
-      <Word>ploeh</Word>
-    </Recognized>
-  </Words>
-</Dictionary>

--- a/Src/Albedo/CompositeReflectionElement.cs
+++ b/Src/Albedo/CompositeReflectionElement.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
-namespace Ploeh.Albedo
+namespace Albedo
 {
     /// <summary>
     /// An implementation of a polymorphic <see cref="IReflectionElement"/> 

--- a/Src/Albedo/ConcreteElementConversions.cs
+++ b/Src/Albedo/ConcreteElementConversions.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
 
-namespace Ploeh.Albedo
+namespace Albedo
 {
     /// <summary>
     /// Provides extension methods which convert from System.Reflection instances to

--- a/Src/Albedo/ConstructorInfoElement.cs
+++ b/Src/Albedo/ConstructorInfoElement.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 
-namespace Ploeh.Albedo
+namespace Albedo
 {
     /// <summary>
     /// An <see cref="IReflectionElement"/> representing a <see cref="ConstructorInfo"/> which

--- a/Src/Albedo/Constructors.cs
+++ b/Src/Albedo/Constructors.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace Ploeh.Albedo
+namespace Albedo
 {
     /// <summary>
     /// Provides strongly-typed, refactoring-safe access to

--- a/Src/Albedo/EventInfoElement.cs
+++ b/Src/Albedo/EventInfoElement.cs
@@ -2,7 +2,7 @@
 using System.Globalization;
 using System.Reflection;
 
-namespace Ploeh.Albedo
+namespace Albedo
 {
     /// <summary>
     /// An <see cref="IReflectionElement"/> representing a <see cref="EventInfo"/> which

--- a/Src/Albedo/FieldInfoElement.cs
+++ b/Src/Albedo/FieldInfoElement.cs
@@ -2,7 +2,7 @@
 using System.Globalization;
 using System.Reflection;
 
-namespace Ploeh.Albedo
+namespace Albedo
 {
     /// <summary>
     /// An <see cref="IReflectionElement"/> representing a <see cref="FieldInfo"/> which

--- a/Src/Albedo/Fields.cs
+++ b/Src/Albedo/Fields.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Text;
 
-namespace Ploeh.Albedo
+namespace Albedo
 {
     /// <summary>
     /// Provides strongly-typed, refactoring-safe access to

--- a/Src/Albedo/IReflectionElement.cs
+++ b/Src/Albedo/IReflectionElement.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Ploeh.Albedo
+﻿namespace Albedo
 {
     /// <summary>
     /// Represents a polymorphic reflection element, which can be visited

--- a/Src/Albedo/IReflectionVisitor.cs
+++ b/Src/Albedo/IReflectionVisitor.cs
@@ -1,4 +1,4 @@
-﻿namespace Ploeh.Albedo
+﻿namespace Albedo
 {
     /// <summary>
     /// Represents a Visitor which can visit <see cref="IReflectionElement" />

--- a/Src/Albedo/LocalVariableInfoElement.cs
+++ b/Src/Albedo/LocalVariableInfoElement.cs
@@ -2,7 +2,7 @@
 using System.Globalization;
 using System.Reflection;
 
-namespace Ploeh.Albedo
+namespace Albedo
 {
     /// <summary>
     /// An <see cref="IReflectionElement"/> representing a <see cref="LocalVariableInfo"/> which

--- a/Src/Albedo/MethodInfoElement.cs
+++ b/Src/Albedo/MethodInfoElement.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 
-namespace Ploeh.Albedo
+namespace Albedo
 {
     /// <summary>
     /// An <see cref="IReflectionElement"/> representing a <see cref="MethodInfo"/> which

--- a/Src/Albedo/Methods.cs
+++ b/Src/Albedo/Methods.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace Ploeh.Albedo
+namespace Albedo
 {
     /// <summary>
     /// Provides strongly-typed, refactoring-safe access to

--- a/Src/Albedo/NullReflectionElement.cs
+++ b/Src/Albedo/NullReflectionElement.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
-namespace Ploeh.Albedo
+namespace Albedo
 {
     /// <summary>
     /// An implementation of IReflectionElement that does nothing.

--- a/Src/Albedo/ParameterInfoElement.cs
+++ b/Src/Albedo/ParameterInfoElement.cs
@@ -2,7 +2,7 @@
 using System.Globalization;
 using System.Reflection;
 
-namespace Ploeh.Albedo
+namespace Albedo
 {
     /// <summary>
     /// An <see cref="IReflectionElement"/> representing a <see cref="ParameterInfo"/> which

--- a/Src/Albedo/Properties.cs
+++ b/Src/Albedo/Properties.cs
@@ -2,7 +2,7 @@
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace Ploeh.Albedo
+namespace Albedo
 {
     /// <summary>
     /// Provides strongly-typed, refactoring-safe access to

--- a/Src/Albedo/PropertyInfoElement.cs
+++ b/Src/Albedo/PropertyInfoElement.cs
@@ -2,7 +2,7 @@
 using System.Globalization;
 using System.Reflection;
 
-namespace Ploeh.Albedo
+namespace Albedo
 {
     /// <summary>
     /// An <see cref="IReflectionElement"/> representing a <see cref="PropertyInfo"/> which

--- a/Src/Albedo/ReflectionElementEnvy.cs
+++ b/Src/Albedo/ReflectionElementEnvy.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-namespace Ploeh.Albedo
+namespace Albedo
 {
     /// <summary>
     /// Contains extension methods for dealing with <see cref="IReflectionElement"/>

--- a/Src/Albedo/ReflectionVisitor.cs
+++ b/Src/Albedo/ReflectionVisitor.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Reflection;
 
-namespace Ploeh.Albedo
+namespace Albedo
 {
     /// <summary>
     /// Represents a Visitor base class which can visit

--- a/Src/Albedo/Refraction/AssemblyElementRefraction.cs
+++ b/Src/Albedo/Refraction/AssemblyElementRefraction.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 
-namespace Ploeh.Albedo.Refraction
+namespace Albedo.Refraction
 {
     /// <summary>
     /// Creates <see cref="AssemblyElement" /> instances from a sequence of

--- a/Src/Albedo/Refraction/CompositeReflectionElementRefraction.cs
+++ b/Src/Albedo/Refraction/CompositeReflectionElementRefraction.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
-namespace Ploeh.Albedo.Refraction
+namespace Albedo.Refraction
 {
     /// <summary>
     /// Composes multiple <see cref="IReflectionElementRefraction{T}" />

--- a/Src/Albedo/Refraction/ConstructorInfoElementRefraction.cs
+++ b/Src/Albedo/Refraction/ConstructorInfoElementRefraction.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 
-namespace Ploeh.Albedo.Refraction
+namespace Albedo.Refraction
 {
     /// <summary>
     /// Creates <see cref="ConstructorInfoElement" /> instances from a sequence

--- a/Src/Albedo/Refraction/Conversions.cs
+++ b/Src/Albedo/Refraction/Conversions.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
-namespace Ploeh.Albedo.Refraction
+namespace Albedo.Refraction
 {
     /// <summary>
     /// Contains conversion methods to turn objects into

--- a/Src/Albedo/Refraction/EventInfoElementRefraction.cs
+++ b/Src/Albedo/Refraction/EventInfoElementRefraction.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 
-namespace Ploeh.Albedo.Refraction
+namespace Albedo.Refraction
 {
     /// <summary>
     /// Creates <see cref="EventInfoElement" /> instances from a sequence of

--- a/Src/Albedo/Refraction/FieldInfoElementRefraction.cs
+++ b/Src/Albedo/Refraction/FieldInfoElementRefraction.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 
-namespace Ploeh.Albedo.Refraction
+namespace Albedo.Refraction
 {
     /// <summary>
     /// Creates <see cref="FieldInfoElement" /> instances from a sequence of

--- a/Src/Albedo/Refraction/IReflectionElementRefraction.cs
+++ b/Src/Albedo/Refraction/IReflectionElementRefraction.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
-namespace Ploeh.Albedo.Refraction
+namespace Albedo.Refraction
 {
     /// <summary>
     /// Creates a sequence of <see cref="IReflectionElement" /> instances from

--- a/Src/Albedo/Refraction/LocalVariableInfoElementRefraction.cs
+++ b/Src/Albedo/Refraction/LocalVariableInfoElementRefraction.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Reflection;
 
-namespace Ploeh.Albedo.Refraction
+namespace Albedo.Refraction
 {
     /// <summary>
     /// Creates <see cref="LocalVariableInfoElement" /> instances from a sequence of

--- a/Src/Albedo/Refraction/MethodInfoElementRefraction.cs
+++ b/Src/Albedo/Refraction/MethodInfoElementRefraction.cs
@@ -1,10 +1,8 @@
-﻿﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 
-namespace Ploeh.Albedo.Refraction
+namespace Albedo.Refraction
 {
     /// <summary>
     /// Creates <see cref="MethodInfoElement" /> instances from a sequence of

--- a/Src/Albedo/Refraction/ParameterInfoElementRefraction.cs
+++ b/Src/Albedo/Refraction/ParameterInfoElementRefraction.cs
@@ -1,10 +1,8 @@
-﻿﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 
-namespace Ploeh.Albedo.Refraction
+namespace Albedo.Refraction
 {
     /// <summary>
     /// Creates <see cref="ParameterInfoElement" /> instances from a sequence of

--- a/Src/Albedo/Refraction/PropertyInfoElementRefraction.cs
+++ b/Src/Albedo/Refraction/PropertyInfoElementRefraction.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Reflection;
 
-namespace Ploeh.Albedo.Refraction
+namespace Albedo.Refraction
 {
     /// <summary>
     /// Creates <see cref="PropertyInfoElement" /> instances from a sequence of

--- a/Src/Albedo/Refraction/ReflectionElementRefraction.cs
+++ b/Src/Albedo/Refraction/ReflectionElementRefraction.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
-namespace Ploeh.Albedo.Refraction
+namespace Albedo.Refraction
 {
     /// <summary>
     /// Filters a sequence of source objects, allowing only

--- a/Src/Albedo/Refraction/TypeElementRefraction.cs
+++ b/Src/Albedo/Refraction/TypeElementRefraction.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
-namespace Ploeh.Albedo.Refraction
+namespace Albedo.Refraction
 {
     /// <summary>
     /// Creates <see cref="TypeElement" /> instances from a sequence of source

--- a/Src/Albedo/TypeElement.cs
+++ b/Src/Albedo/TypeElement.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 
-namespace Ploeh.Albedo
+namespace Albedo
 {
     /// <summary>
     /// An <see cref="IReflectionElement"/> representing a <see cref="System.Type"/> which

--- a/Src/Albedo/ValueCollectingVisitor.cs
+++ b/Src/Albedo/ValueCollectingVisitor.cs
@@ -2,9 +2,8 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
 
-namespace Ploeh.Albedo
+namespace Albedo
 {
     /// <summary>
     /// Represents a Visitor which can visit <see cref="IReflectionElement" /> instances,


### PR DESCRIPTION
Closes #97.

To reflect the change in Governance model we remove the "Ploeh" namespace and assembly prefix.

